### PR TITLE
Show Rwm for MULx instructions

### DIFF
--- a/data/languages/c166.sinc
+++ b/data/languages/c166.sinc
@@ -1686,7 +1686,7 @@ define pcodeop __service_watchdog;
 # ------
 
 # MUL Rwn, Rwm
-:mul rwn is ExtCountDec & op=0x0B & rwn & rwm {
+:mul rwn, rwm is ExtCountDec & op=0x0B & rwn & rwm {
 	local res:4 = sext(rwn) * sext(rwm);
 	MDL = res:2;
 	res = res >> 16;
@@ -1699,7 +1699,7 @@ define pcodeop __service_watchdog;
 # ------
 
 # MULU Rwn, Rwm
-:mulu rwn is ExtCountDec & op=0x1B & rwn & rwm {
+:mulu rwn, rwm is ExtCountDec & op=0x1B & rwn & rwm {
 	local res:4 = zext(rwn) * zext(rwm);
 	MDL = res:2;
 	res = res >> 16;


### PR DESCRIPTION
This fixes the case where the listings view does not show the second register that is used for a mul/mulu instruction