### PR TITLE
Custom calling convention: R2..R5

### DIFF
--- a/data/languages/c166.cspec
+++ b/data/languages/c166.cspec
@@ -111,4 +111,52 @@
             </killedbycall>
         </prototype>
     </default_proto>
+
+		<prototype name="__r2_r5_call" extrapop="4" stackshift="4" strategy="register">
+			<input>
+				<pentry minsize="1" maxsize="2">
+					<register name="r2" />
+				</pentry>
+				<pentry minsize="1" maxsize="2">
+					<register name="r3" />
+				</pentry>
+				<pentry minsize="3" maxsize="4">
+					<addr space="join" piece1="r3" piece2="r2"/>
+				</pentry>
+				<pentry minsize="1" maxsize="2">
+					<register name="r4" />
+				</pentry>
+				<pentry minsize="1" maxsize="2">
+					<register name="r5" />
+				</pentry>
+				<pentry minsize="3" maxsize="4">
+					<addr space="join" piece1="r5" piece2="r4"/>
+				</pentry>
+				<pentry minsize="1" maxsize="500" align="2">
+					<addr offset="16" space="stack"/>
+				</pentry>
+			</input>
+			<output>
+				<pentry minsize="1" maxsize="1">
+					<register name="RL2" />
+				</pentry>
+				<pentry minsize="2" maxsize="2">
+					<register name="r2" />
+				</pentry>
+				<pentry minsize="3" maxsize="4">
+					<addr space="join" piece1="r3" piece2="r2"/>
+				</pentry>
+			</output>
+            <killedbycall>
+                <register name="r1"/>       <!-- Volatile registers -->
+                <register name="r2"/>
+                <register name="r3"/>
+                <register name="r4"/>
+                <register name="r5"/>
+            </killedbycall>
+	      <localrange>
+	        <range space="stack" first="0xF600" last="0xFFFF"/>
+	      </localrange>
+		</prototype>
+
 </compiler_spec>


### PR DESCRIPTION
I have worked with several vehicle electronic modules built on XC2xxx (Infineon MCU based on a C166 core).

And I found that they use r2..r5 to store function parameters and r2 to return value.
Don't know what is the name of this compiler but it looks like it was quite popular 10..15 year ago in this area.

Some weird fact: they may use __stadcall (r11..r14) in the same binary (most likely, it's a some library).