### PR TITLE
feat(cspec): add __keil_c166 calling convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ For best results, set DPP register values in Ghidra:
 2. `Right-click` → `Set Register Values`
 3. Set `DPP0`-`DPP3` to appropriate page values
 
+## Calling Conventions
+
+The module ships two calling conventions; pick per function via the
+function signature editor (`F` in the listing) or set automatically by
+the *Decompiler Parameter ID* analyzer.
+
+| Name | Compiler | Word params | 32-bit / pointer pairs | Return word | Notes |
+|------|----------|-------------|------------------------|-------------|-------|
+| `__stdcall` (default) | Tasking c166 / generic | R12, R13, R14, R15 | R13/R12, R15/R14 | R4 (RL4 char) | Tasking convention; suitable for binaries built with Tasking c166 or unknown toolchains. |
+| `__keil_c166` | Keil Cx66 / µVision | R8, R9, R10, R11, R12 | R9/R8, R11/R10 | R4 (RL4 char) | Keil convention; common in automotive ECUs and other Infineon C16x application code. Bit parameters (R15.0, R15.1, …) are not modeled. |
+
+Both conventions return 32-bit values (long, far pointer) in the **R4/R5**
+pair and assume **R0** as user stack pointer.
+
+If the decompiler shows parameters on the stack and ignores values being
+read from R8–R12 in a Keil-built binary, switch the function's calling
+convention to `__keil_c166` — the decompiler will then recover the
+parameters correctly.
+
 ## Supported Processors
 
 - Infineon C167CR

--- a/data/languages/c166.cspec
+++ b/data/languages/c166.cspec
@@ -121,4 +121,86 @@
             </killedbycall>
         </prototype>
     </default_proto>
+
+    <!--
+        Keil C166 calling convention (compiler-specific).
+        Used by binaries built with Keil Cx66 / uVision toolchain (e.g. automotive door
+        controllers, Infineon C16x application code).
+
+        Reference: Keil C166 User's Guide, "Function Parameters" + "SMALL/MEDIUM Model".
+          - Parameters 1..5 (word):       R8, R9, R10, R11, R12
+          - 32-bit / long / far pointer:  register pairs R8/R9, R10/R11
+          - Bit parameters:               R15.0, R15.1, ... (not modeled here)
+          - Overflow:                     user stack via [R0+#disp]
+          - Return word:                  R4 (RL4 for char)
+          - Return long / float / farptr: R4/R5 pair
+          - User stack pointer:           R0 (already declared globally)
+          - Callee-saved (unaffected):    R0..R3, R6, R7
+          - Volatile (killed by call):    R4, R5, R10, R11, PSW, MDH, MDL, MDC
+    -->
+    <prototype name="__keil_c166" extrapop="0" stackshift="0" strategy="register">
+        <input>
+            <pentry minsize="1" maxsize="2">
+                <register name="r8"/>
+            </pentry>
+            <pentry minsize="1" maxsize="2">
+                <register name="r9"/>
+            </pentry>
+            <pentry minsize="3" maxsize="4">
+                <addr space="join" piece1="r9" piece2="r8"/>
+            </pentry>
+            <pentry minsize="1" maxsize="2">
+                <register name="r10"/>
+            </pentry>
+            <pentry minsize="1" maxsize="2">
+                <register name="r11"/>
+            </pentry>
+            <pentry minsize="3" maxsize="4">
+                <addr space="join" piece1="r11" piece2="r10"/>
+            </pentry>
+            <pentry minsize="1" maxsize="2">
+                <register name="r12"/>
+            </pentry>
+            <pentry minsize="1" maxsize="500" align="2">
+                <addr offset="0" space="stack"/>
+            </pentry>
+        </input>
+        <output>
+            <pentry minsize="1" maxsize="1">
+                <register name="RL4"/>
+            </pentry>
+            <pentry minsize="1" maxsize="2">
+                <register name="r4"/>
+            </pentry>
+            <pentry minsize="3" maxsize="4">
+                <addr space="join" piece1="r5" piece2="r4"/>
+            </pentry>
+        </output>
+        <unaffected>
+            <register name="r0"/>
+            <register name="r1"/>
+            <register name="r2"/>
+            <register name="r3"/>
+            <register name="r6"/>
+            <register name="r7"/>
+            <register name="DPP0"/>
+            <register name="DPP1"/>
+            <register name="DPP2"/>
+            <register name="DPP3"/>
+            <register name="CP"/>
+        </unaffected>
+        <killedbycall>
+            <register name="r4"/>
+            <register name="r5"/>
+            <register name="r8"/>       <!-- param 1 (also returns) -->
+            <register name="r9"/>       <!-- param 2 -->
+            <register name="r10"/>      <!-- param 3 -->
+            <register name="r11"/>      <!-- param 4 -->
+            <register name="r12"/>      <!-- param 5 -->
+            <register name="PSW"/>
+            <register name="MDH"/>
+            <register name="MDL"/>
+            <register name="MDC"/>
+        </killedbycall>
+    </prototype>
 </compiler_spec>


### PR DESCRIPTION
Adds a second calling convention next to the default Tasking-style
`__stdcall`, modelling the Keil Cx66 compiler's parameter passing scheme:

  - Word params 1..5  → R8, R9, R10, R11, R12
  - 32-bit param pairs → R8/R9, R10/R11
  - Stack overflow    → `[R0+#disp]`
  - Return word       → R4 (RL4 for char)
  - Return long/farptr→ R4/R5 pair
  - Callee-saved      → R0..R3, R6, R7, DPP0..3, CP
  - Killed by call    → R4, R5, R8..R12, PSW, MDH, MDL, MDC

Without this, binaries built with Keil's toolchain (common in
automotive door controllers and other Infineon C16x application code)
decompile with parameters reported on the stack and R8..R12 left as
untracked locals, blocking decompiler-based parameter recovery.

Reference: Keil C166 User's Guide, "Function Parameters" + "SMALL/MEDIUM Model".
Pattern follows PR #21 (custom R2..R5 convention by @esaulenka).

README updated with a comparison table so users with Keil-built
binaries know to switch the function's calling convention to
`__keil_c166` when register parameter recovery is missing.