### PR TITLE
fix(get-paged-offset): pass raw offset through when DPP/EXTP/EXTS unknown

### DIFF
--- a/src/main/java/ghidrainfineon/GetPagedOffset.java
+++ b/src/main/java/ghidrainfineon/GetPagedOffset.java
@@ -38,28 +38,29 @@ public class GetPagedOffset extends InjectPayloadCallother {
 
 	private long getEffectiveAddress(Program program, Address baseAddress, long offset) {
 		int dppNum = Math.toIntExact((offset & 0xC000) >> 14);
-		long value = dppNum;
 		BigInteger PageRegister = program.getProgramContext().getValue(program.getRegister("DPP" + dppNum), baseAddress, false);
 		BigInteger ExtpEnRegister = program.getProgramContext().getValue(program.getRegister("ExtpEn"), baseAddress, false);
 		BigInteger ExtsEnRegister = program.getProgramContext().getValue(program.getRegister("ExtsEn"), baseAddress, false);
 
 		if (ExtpEnRegister != null && ExtpEnRegister.equals(BigInteger.ONE)) {
-			BigInteger bigInteger = program.getProgramContext().getValue(program.getRegister("Extp"), baseAddress, false);
-			if (bigInteger != null) {
-				value = bigInteger.longValue() << 14;
-                offset = offset & 0x3FFF;
+			BigInteger page = program.getProgramContext().getValue(program.getRegister("Extp"), baseAddress, false);
+			if (page != null) {
+				return ((page.longValue() & 0x3FFL) << 14) | (offset & 0x3FFF);
 			}
 		} else if (ExtsEnRegister != null && ExtsEnRegister.equals(BigInteger.ONE)) {
-			BigInteger bigInteger = program.getProgramContext().getValue(program.getRegister("Exts"), baseAddress, false);
-			if (bigInteger != null) {
-				value = bigInteger.longValue() << 16;
+			BigInteger seg = program.getProgramContext().getValue(program.getRegister("Exts"), baseAddress, false);
+			if (seg != null) {
+				return ((seg.longValue() & 0xFFL) << 16) | (offset & 0xFFFF);
 			}
 		} else if (PageRegister != null) {
-			value = PageRegister.longValue() << 14;
-            offset = offset & 0x3FFF;
+			return ((PageRegister.longValue() & 0x3FFL) << 14) | (offset & 0x3FFF);
 		}
 
-		return value + offset;
+		// No translation context available (DPP/EXTP/EXTS unknown at this site):
+		// pass the raw 16-bit offset through unchanged so xref targets stay
+		// consistent with the disassembly operand and with C166AddressAnalyzer's
+		// translateAddress fallback.
+		return offset & 0xFFFF;
 	}
 	
 	@Override


### PR DESCRIPTION
## Problem

When `GetPagedOffset.getEffectiveAddress` cannot resolve any DPP/EXTP/EXTS
translation context at the load site, the method falls out of all
if/else-if branches with `value` still holding its initialiser `dppNum`
(0..3, derived from the upper two bits of the raw operand) and `offset`
left unmasked. The trailing `return value + offset` then produces an
address shifted `dppNum` bytes past the operand encoded in the
instruction.

Concrete repro on a real binary:

| Aspect       | Value |
|--------------|-------|
| Bytes @ a    | `F2 F6 02 93` (`mov r6, mem`) |
| Encoded mem  | `0x9302` (DPP-num = 2) |
| Listing op   | `mov r6, 0x9302` |
| Resolved ref | `ram:009304` (Source: ANALYSIS) |
| DPP context  | `DPP2 = null` at this address |

So Ghidra creates an analysis xref two bytes past the real operand
whenever DPP state isn't known there — the common case at function
entry on binaries that don't reload DPPs near every direct access.

## Fix

* Drop the `value = dppNum` initialiser.
* In each translation branch, return the resolved address inline.
* On fall-through, return the raw 16-bit offset unchanged.

This matches `C166AddressAnalyzer.translateAddress`'s "return null →
filtered fallback" behaviour, so the two analysis paths now agree.

## Verification

After applying the fix and re-running auto-analysis on the test
binary, `inst.getReferencesFrom()` returns `ram:009302` (the correct
encoded operand) instead of `ram:009304`.

## Possibly related

This may overlap with #28 — the symptom there (DPP2 set to 0x3C,
address off by 0x400) isn't 100 % the same scenario, so I'm not
claiming this closes it. Worth a sanity-check from the original
reporter; left a note on the issue.
Schritt 4 — Issue #28 kommentieren
Auf https://github.com/keyhana/c166-ghidra-module/issues/28 ein neuer Kommentar:


While debugging an unrelated decompile inconsistency I found a related
fall-through bug in `GetPagedOffset.getEffectiveAddress` — when
DPP/EXTP/EXTS state is unresolved at the load site, the method's
`value = dppNum` initialiser leaks into the result, producing addresses
0..3 bytes past the encoded operand.

Repro on my binary: bytes `F2 F6 02 93` at instruction address X with
`DPP2 = null`, encoded operand `0x9302`, but `inst.getReferencesFrom()`
returns `ram:009304` with `source = ANALYSIS`. After fix, the reference
correctly lands on `ram:009302`.

PR with the fix and full analysis: <Link zum gerade erstellten PR>

It probably doesn't fully cover your scenario (you described
`DPP2 = 0x3C` *at* the time of the access, not unset), but it's
plausible the same code path is involved if your DPP propagation
isn't reaching the access site. If you have the test binary handy,
a re-test with the patched module would help narrow it down.