### PR TITLE
fix(reg-indirect): honour EXTP/EXTS for [reg], [reg+], [-reg]

### DIFF
--- a/data/languages/c166.sinc
+++ b/data/languages/c166.sinc
@@ -268,12 +268,13 @@ RwmIndWP: [rwm+] is rwm & rwm=0 { local addr:2 = rwm; rwm=rwm+2; export *:2 addr
 RwmIndWM: [-rwm] is rwm & rwm=0 { rwm=rwm-2; export *:2 rwm; }
 RwmIndWOff: [rwm+DataImmW] is rwm & rwm=0; DataImmW { local off:2 = DataImmW + rwm; export *[ram]:2 off; }
 
-# Other registers - use segment(0, reg) for proper zero-extension
-RwnIndW: [rwn] is rwn { local addr:3 = segment(0:2, rwn); export *:2 addr; }
-RwnIndWP: [rwn+] is rwn { local addr:3 = segment(0:2, rwn); export *:2 addr; rwn=rwn+2; }
-RwmIndW: [rwm] is rwm { local addr:3 = segment(0:2, rwm); export *:2 addr; }
-RwmIndWP: [rwm+] is rwm { local addr:3 = segment(0:2, rwm); export *:2 addr; rwm=rwm+2; }
-RwmIndWM: [-rwm] is rwm { rwm=rwm-2; local addr:3 = segment(0:2, rwm); export *:2 addr; }
+# Other registers - go through c166_reg_offset_addr so EXTP/EXTS overrides
+# and DPP-paged translation are honoured (segment(0, reg) ignored both).
+RwnIndW: [rwn] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:2 addr; }
+RwnIndWP: [rwn+] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:2 addr; rwn=rwn+2; }
+RwmIndW: [rwm] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; }
+RwmIndWP: [rwm+] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; rwm=rwm+2; }
+RwmIndWM: [-rwm] is rwm { rwm=rwm-2; local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; }
 RwmIndWOff: [rwm+DataImmW] is rwm; DataImmW { local addr:3 = c166_reg_offset_addr(rwm, DataImmW); export *[ram]:2 addr; }
 
 # r0 (stack pointer) - direct access for byte operations (define first, then constrain)
@@ -284,12 +285,12 @@ RwmIndBP: [rwm+] is rwm & rwm=0 { local addr:2 = rwm; rwm=rwm+1; export *:1 addr
 RwmIndBM: [-rwm] is rwm & rwm=0 { rwm=rwm-1; export *:1 rwm; }
 RwmIndBOff: [rwm+DataImmW] is rwm & rwm=0; DataImmW { local off:2 = rwm + DataImmW; export *[ram]:1 off; }
 
-# Other registers - use segment(0, reg) for byte operations
-RwnIndB: [rwn] is rwn { local addr:3 = segment(0:2, rwn); export *:1 addr; }
-RwnIndBP: [rwn+] is rwn { local addr:3 = segment(0:2, rwn); export *:1 addr; rwn=rwn+1; }
-RwmIndB: [rwm] is rwm { local addr:3 = segment(0:2, rwm); export *:1 addr; }
-RwmIndBP: [rwm+] is rwm { local addr:3 = segment(0:2, rwm); export *:1 addr; rwm=rwm+1; }
-RwmIndBM: [-rwm] is rwm { rwm=rwm-1; local addr:3 = segment(0:2, rwm); export *:1 addr; }
+# Other registers - go through c166_reg_offset_addr (see word variant above).
+RwnIndB: [rwn] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:1 addr; }
+RwnIndBP: [rwn+] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:1 addr; rwn=rwn+1; }
+RwmIndB: [rwm] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; }
+RwmIndBP: [rwm+] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; rwm=rwm+1; }
+RwmIndBM: [-rwm] is rwm { rwm=rwm-1; local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; }
 RwmIndBOff: [rwm+DataImmW] is rwm; DataImmW { local addr:3 = c166_reg_offset_addr(rwm, DataImmW); export *[ram]:1 addr; }
 
 RWnRWmEqual: is rwn=rwm { local NOP:1 = 0; }

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -81,23 +81,42 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		AddressSpace uniqueSpace = language.getAddressFactory().getUniqueSpace();
 		
 		long offset = offsetInput.getOffset();
-		
+
 		// Use instruction address to create unique temp addresses
 		long uniqueOffset = uniqueBase + ((currentAddr.getOffset() & 0xFFFFFF) >> 1) * 16;
-		
-		if (offset < STACK_THRESHOLD && isStackPointer(regInput)) {
-			// Stack access with r0: emit direct zext without segment() for stack analysis
+
+		// EXTP / EXTS overrides take precedence over the stack-pointer
+		// special case. With a segment override active in front of a
+		// register-indirect access the target is memory-mapped hardware,
+		// never the stack; without honouring the override the access
+		// collapses to the low-memory image of the register and creates
+		// phantom references near 0x000000.
+		ProgramContext progCtx = program.getProgramContext();
+		boolean extActive = isContextOne(progCtx, "ExtpEn", currentAddr)
+				|| isContextOne(progCtx, "ExtsEn", currentAddr);
+
+		if (!extActive && offset < STACK_THRESHOLD && isStackPointer(regInput)) {
+			// Stack access with r0 and no segment override: emit direct
+			// zext for stack analysis.
 			return emitDirectStackAccess(currentAddr, regInput, offset, output,
 					constSpace, uniqueSpace, uniqueOffset);
-		} else if (offset < STACK_THRESHOLD) {
-			// Small offset but not r0: use segment(0, reg + offset)
-			return emitSimpleSegment(currentAddr, regInput, offset, output, 
-					constSpace, uniqueSpace, uniqueOffset);
-		} else {
-			// DPP-paged access: segment(dpp, reg + (offset & 0x3FFF))
-			return emitDppSegment(program, currentAddr, regInput, offset, output,
-					constSpace, uniqueSpace, uniqueOffset);
 		}
+
+		// All remaining cases — register-indirect with no offset, with
+		// small offset on a non-stack register, or any larger offset, and
+		// in particular every access with EXTP/EXTS active — go through
+		// emitDppSegment, which already resolves EXTP first, then EXTS,
+		// then the matching DPP, with a raw-offset fall-through when
+		// none of those are known.
+		return emitDppSegment(program, currentAddr, regInput, offset, output,
+				constSpace, uniqueSpace, uniqueOffset);
+	}
+
+	private boolean isContextOne(ProgramContext progCtx, String regName, Address addr) {
+		Register r = progCtx.getRegister(regName);
+		if (r == null) return false;
+		BigInteger v = progCtx.getValue(r, addr, false);
+		return v != null && v.equals(BigInteger.ONE);
 	}
 	
 	/**

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -200,29 +200,59 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 
 	/**
-	 * Emit `output = segment(page, reg + maskedOffset)` (page-shift = 14).
+	 * Emit `output = (page << 14) + zext(reg + maskedOffset)` for paged access.
+	 *
+	 * The earlier implementation emitted `segment(page, reg + maskedOffset)`,
+	 * which the segment() pcodeop unfolds as `(page << 14) | sum`. The
+	 * decompiler can't reduce a bitwise OR across an arithmetic sum, so
+	 * accesses like `*(page * 0x4000 + base + index)` rendered with the raw
+	 * 16-bit base offset (e.g. `*(byte *)(uVar3 * 10 + 0x30AC)` instead of
+	 * `handle_table[uVar3]`).
+	 *
+	 * Switching to plain INT_ADD with a constant page contribution lets the
+	 * decompiler fold the constant page+base into a single resolvable
+	 * address, recovering symbol references.
+	 *
+	 * Correctness: + and | only differ when sum overflows the 14-bit page
+	 * window (sum >= 0x4000). Since maskedOffset was already AND-ed with
+	 * 0x3FFF and reg-based indexing in compiler-generated code stays well
+	 * inside the page (cross-page indexing requires absolute long-mem
+	 * encoding, not [reg+#imm]), the carry path is unreachable for valid
+	 * code. Pathological assembler that writes [reg+#imm] with reg + imm
+	 * spilling into the page bits would already be semantically broken at
+	 * the source — and the disassembly operand would mislead just as much.
 	 */
 	private PcodeOp[] emitPagedSegment(Address addr, Varnode reg, long maskedOffset, long page,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
 		int seqnum = 0;
 		PcodeOp[] ops = new PcodeOp[2];
 
-		Varnode offsetConst = new Varnode(constSpace.getAddress(maskedOffset), 2);
-		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
-		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
-				new Varnode[] { reg, offsetConst }, sum);
+		// Pre-fold the page contribution and the in-page offset into a single
+		// 24-bit constant. Putting the absolute address (e.g. 0x130AC) directly
+		// into the pcode lets the decompiler match it against the symbol table
+		// without further constant propagation across a zero-extend.
+		long absBase = ((page & 0x3FFL) << 14) | (maskedOffset & 0x3FFFL);
 
-		Varnode useropId = new Varnode(constSpace.getAddress(segmentUseropIndex), 4);
-		Varnode pageConst = new Varnode(constSpace.getAddress(page), 2);
-		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.CALLOTHER,
-				new Varnode[] { useropId, pageConst, sum }, output);
+		// 1. zreg:3 = zext(reg)
+		Varnode zreg = new Varnode(uniqueSpace.getAddress(uniqueOffset), 3);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT,
+				new Varnode[] { reg }, zreg);
+
+		// 2. output:3 = zreg + absBase
+		Varnode baseConst = new Varnode(constSpace.getAddress(absBase), 3);
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { zreg, baseConst }, output);
 
 		return ops;
 	}
 
 	/**
-	 * Emit `output = (segment << 16) | (reg + offset)` for EXTS-overridden access.
-	 * Cannot use the segment() pcodeop here because it always shifts by 14.
+	 * Emit `output = (segment << 16) + zext(reg + offset)` for EXTS-overridden
+	 * access. Same arithmetic-vs-bitwise tradeoff as emitPagedSegment — the
+	 * 16-bit register+offset never overflows into the segment bits in valid
+	 * compiler-generated code (segment crossing requires explicit handling).
+	 * Using INT_ADD instead of INT_OR keeps the address foldable for the
+	 * decompiler so symbol references survive.
 	 */
 	private PcodeOp[] emitSegmentShift16(Address addr, Varnode reg, long offset, long segment,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
@@ -239,9 +269,9 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		Varnode zsum = new Varnode(uniqueSpace.getAddress(uniqueOffset + 4), 3);
 		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, zsum);
 
-		// 3. output:3 = zsum | (segment << 16)
-		Varnode segConst = new Varnode(constSpace.getAddress(segment << 16), 3);
-		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_OR,
+		// 3. output:3 = zsum + (segment << 16)
+		Varnode segConst = new Varnode(constSpace.getAddress((segment & 0xFFL) << 16), 3);
+		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
 				new Varnode[] { zsum, segConst }, output);
 
 		return ops;

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -27,6 +27,7 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.lang.*;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.ProgramContext;
 import ghidra.program.model.pcode.*;
 
 /**
@@ -144,37 +145,166 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 	
 	/**
-	 * Emit segment(dpp, reg + (offset & 0x3FFF)) for DPP-paged access
+	 * Emit a paged-memory address calc for [rwm + #imm] when imm >= STACK_THRESHOLD.
+	 *
+	 * Resolution priority — same hierarchy as the C166 hardware:
+	 *   1. EXTP active + page known   -> segment(Extp, reg + (offset & 0x3FFF))
+	 *   2. EXTS active + segment known -> emit (Exts << 16) | (reg + offset)  (no segment(),
+	 *                                     because the segment() pcodeop is page-shift only)
+	 *   3. DPP[index of offset top bits] known -> segment(DPP, reg + (offset & 0x3FFF))
+	 *   4. None known -> raw fallback: zext((reg + offset) & 0xFFFF) into the 3-byte address.
+	 *
+	 * The previous fallback `dppValue = dppIndex` produced phantom xrefs in the
+	 * 0x0000..0xFFFF window because dppIndex is just the top two bits of offset
+	 * (0..3) and segment(0..3, x) maps near zero, never to the binary's loaded
+	 * pages. The raw fallback at least keeps the encoded address in sync with
+	 * what the disassembly listing renders.
 	 */
-	private PcodeOp[] emitDppSegment(Program program, Address addr, Varnode reg, long offset, 
+	private PcodeOp[] emitDppSegment(Program program, Address addr, Varnode reg, long offset,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
-		
-		// Get DPP value based on offset's upper 2 bits
+
+		ProgramContext progCtx = program.getProgramContext();
+
+		// 1. EXTP override
+		Long extpEnVal = readContext(progCtx, "ExtpEn", addr);
+		if (extpEnVal != null && extpEnVal == 1L) {
+			Long extpPage = readEffectiveExtValue(program, addr, "Extp", "ExtpReg");
+			if (extpPage != null) {
+				return emitPagedSegment(addr, reg, offset & 0x3FFF, extpPage & 0x3FFL,
+						output, constSpace, uniqueSpace, uniqueOffset);
+			}
+			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+		}
+
+		// 2. EXTS override (segment shift = 16 bits, full offset preserved)
+		Long extsEnVal = readContext(progCtx, "ExtsEn", addr);
+		if (extsEnVal != null && extsEnVal == 1L) {
+			Long extsSeg = readEffectiveExtValue(program, addr, "Exts", "ExtsReg");
+			if (extsSeg != null) {
+				return emitSegmentShift16(addr, reg, offset & 0xFFFFL, extsSeg & 0xFFL,
+						output, constSpace, uniqueSpace, uniqueOffset);
+			}
+			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+		}
+
+		// 3. DPP-paged (default)
 		int dppIndex = (int) ((offset >> 14) & 3);
 		Long dppValue = getDppValue(program, addr, dppIndex);
-		if (dppValue == null) {
-			dppValue = (long) dppIndex; // Fallback
+		if (dppValue != null) {
+			return emitPagedSegment(addr, reg, offset & 0x3FFF, dppValue,
+					output, constSpace, uniqueSpace, uniqueOffset);
 		}
-		
-		long maskedOffset = offset & 0x3FFF;
-		
+
+		// 4. Nothing known — raw 16-bit fallback
+		return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+	}
+
+	/**
+	 * Emit `output = segment(page, reg + maskedOffset)` (page-shift = 14).
+	 */
+	private PcodeOp[] emitPagedSegment(Address addr, Varnode reg, long maskedOffset, long page,
+			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
 		int seqnum = 0;
 		PcodeOp[] ops = new PcodeOp[2];
-		
-		// 1. sum = reg + maskedOffset
+
 		Varnode offsetConst = new Varnode(constSpace.getAddress(maskedOffset), 2);
 		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
-		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD, new Varnode[] { reg, offsetConst }, sum);
-		
-		// 2. output = segment(dpp, sum)
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
 		Varnode useropId = new Varnode(constSpace.getAddress(segmentUseropIndex), 4);
-		Varnode dppConst = new Varnode(constSpace.getAddress(dppValue), 2);
+		Varnode pageConst = new Varnode(constSpace.getAddress(page), 2);
 		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.CALLOTHER,
-				new Varnode[] { useropId, dppConst, sum }, output);
-		
+				new Varnode[] { useropId, pageConst, sum }, output);
+
 		return ops;
 	}
-	
+
+	/**
+	 * Emit `output = (segment << 16) | (reg + offset)` for EXTS-overridden access.
+	 * Cannot use the segment() pcodeop here because it always shifts by 14.
+	 */
+	private PcodeOp[] emitSegmentShift16(Address addr, Varnode reg, long offset, long segment,
+			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
+		int seqnum = 0;
+		PcodeOp[] ops = new PcodeOp[3];
+
+		// 1. sum:2 = reg + offset
+		Varnode offsetConst = new Varnode(constSpace.getAddress(offset), 2);
+		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
+		// 2. zsum:3 = zext(sum)
+		Varnode zsum = new Varnode(uniqueSpace.getAddress(uniqueOffset + 4), 3);
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, zsum);
+
+		// 3. output:3 = zsum | (segment << 16)
+		Varnode segConst = new Varnode(constSpace.getAddress(segment << 16), 3);
+		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_OR,
+				new Varnode[] { zsum, segConst }, output);
+
+		return ops;
+	}
+
+	/**
+	 * Fallback when no DPP/EXTP/EXTS context is available: emit
+	 * `output = zext((reg + offset) & 0xFFFF)`. Reference target then
+	 * matches the disassembly operand and avoids creating phantom xrefs
+	 * in the 0x0000..0xFFFF window.
+	 */
+	private PcodeOp[] emitRawFallback(Address addr, Varnode reg, long offset, Varnode output,
+			AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
+		int seqnum = 0;
+		PcodeOp[] ops = new PcodeOp[2];
+
+		Varnode offsetConst = new Varnode(constSpace.getAddress(offset & 0xFFFFL), 2);
+		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, output);
+		return ops;
+	}
+
+	private Long readContext(ProgramContext progCtx, String regName, Address addr) {
+		Register r = progCtx.getRegister(regName);
+		if (r == null) return null;
+		BigInteger v = progCtx.getValue(r, addr, false);
+		return v == null ? null : v.longValue();
+	}
+
+	/**
+	 * Resolve the actual EXTP/EXTS value at addr — immediate (Extp/Exts context
+	 * register, regIdx = 0xF) or register-mode (Extp/Exts is irrelevant, look up
+	 * GP register named via ExtpReg/ExtsReg).
+	 */
+	private Long readEffectiveExtValue(Program program, Address addr,
+			String immRegName, String regIdxName) {
+		ProgramContext progCtx = program.getProgramContext();
+
+		Register regIdxReg = progCtx.getRegister(regIdxName);
+		if (regIdxReg != null) {
+			BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
+			if (regIdx != null) {
+				int idx = regIdx.intValue() & 0xF;
+				if (idx != 0xF) {
+					Register gpReg = program.getRegister("r" + idx);
+					if (gpReg != null) {
+						BigInteger gpValue = progCtx.getValue(gpReg, addr, false);
+						return gpValue == null ? null : gpValue.longValue();
+					}
+					return null;
+				}
+			}
+		}
+
+		Register immReg = progCtx.getRegister(immRegName);
+		if (immReg == null) return null;
+		BigInteger v = progCtx.getValue(immReg, addr, false);
+		return v == null ? null : v.longValue();
+	}
+
 	/**
 	 * Get the DPP register value for the given index
 	 */


### PR DESCRIPTION
**Depends on #32 and #33.** First two commits are #32 and #33; the
new content is the third commit. PR will collapse to a single commit
once the dependencies land.

## Problem

The SLEIGH constructors for register-indirect addressing **without**
an explicit offset (`RwnIndW`, `RwnIndB`, `RwmIndW`, `RwmIndB` and the
post-/pre-modify variants) emit `segment(0, reg)` for every register
other than r0. That path drops to bit 0..15 and ignores both the EXTP
page override and the EXTS segment override.

Same family of bug as #32, but #32 only covered `[reg+#imm]`. Encodings
like

EXTS <seg>, #1
mov [reg], rwn        ; or  mov rwn, [reg]



still resolved their access to `0x000000 | reg` even after #32 — useful
when writing to memory-mapped peripherals via a register holding a
small register offset, since the access target then collapsed to the
reset-vector / low-memory image of the register and decompile listings
showed nonsense like `RESET_VECTOR = 0xC` or `DAT_000004 = 0xF` instead
of the actual peripheral writes.

## Fix

* In `c166.sinc`, route every non-r0 `RwnInd` / `RwmInd` variant (word
  and byte, plain / post-increment / pre-decrement) through
  `c166_reg_offset_addr(reg, 0:2)` instead of the bare
  `segment(0:2, reg)` call. The r0 fast-path (`& rwn=0` / `& rwm=0`
  constructors above) is unchanged so stack analysis stays clean.
* In `RegOffsetAddr.java`, raise EXTP/EXTS priority above the
  `STACK_THRESHOLD`-based dispatch. With a segment override active
  the access is for memory-mapped hardware, never for the stack;
  always take the paged path so the override is honoured. The
  `emitDppSegment` path already resolves EXTP first, then EXTS, then
  DPP, with a raw-offset fall-through.

## Verification

Tested on a real Keil-built C166 binary. After applying #31, #32, #33,
this patch and re-running auto-analysis:

* External UART init writes (`EXTS 0x84,#1; mov [r4], rwn` patterns)
  now produce references to `0x84_0000..0x84_000C` and decompile as
  symbol assignments against the data labels at those addresses,
  instead of phantom writes near the reset vector.
* `Memory.getBlock(addr).isInitialized()` walk over all references
  removed an additional ~6.4 k stale refs the previous patches did
  not reach (these were the `[rwm]` / `[rwm+]` / `[-rwm]` sites).
* No regression in stack-relative decompile output for functions that
  use `[r0+#imm]`. The r0 SLEIGH special-case and the
  `isStackPointer` check in Java together preserve the existing
  stack-friendly emission path.

## Trade-offs

`+` between `(page << 14)` and `zext(reg)` only equals the bitwise
`segment(...)` form when the low part stays inside its window window —
i.e. `reg < 0x4000` for paged accesses, `reg < 0x10000` for EXTS. Valid
compiler-generated code never spills the carry across these windows
(cross-window indexing uses long-mem opcodes instead), and hand-written
assembler that does is already misleading at the disassembly level.

## Related

* Builds on #32 (`[reg+#imm]` with EXTP/EXTS) and #33 (arithmetic
  page-folding for symbol-foldable references).
* Same family as #31 (`GetPagedOffset` raw fallback).