### PR TITLE
fix: resolve register-mode EXTP/EXTS pcode targets (incl. r15 sentinel fix)

### DIFF
--- a/data/languages/c166.sinc
+++ b/data/languages/c166.sinc
@@ -268,12 +268,13 @@ RwmIndWP: [rwm+] is rwm & rwm=0 { local addr:2 = rwm; rwm=rwm+2; export *:2 addr
 RwmIndWM: [-rwm] is rwm & rwm=0 { rwm=rwm-2; export *:2 rwm; }
 RwmIndWOff: [rwm+DataImmW] is rwm & rwm=0; DataImmW { local off:2 = DataImmW + rwm; export *[ram]:2 off; }
 
-# Other registers - use segment(0, reg) for proper zero-extension
-RwnIndW: [rwn] is rwn { local addr:3 = segment(0:2, rwn); export *:2 addr; }
-RwnIndWP: [rwn+] is rwn { local addr:3 = segment(0:2, rwn); export *:2 addr; rwn=rwn+2; }
-RwmIndW: [rwm] is rwm { local addr:3 = segment(0:2, rwm); export *:2 addr; }
-RwmIndWP: [rwm+] is rwm { local addr:3 = segment(0:2, rwm); export *:2 addr; rwm=rwm+2; }
-RwmIndWM: [-rwm] is rwm { rwm=rwm-2; local addr:3 = segment(0:2, rwm); export *:2 addr; }
+# Other registers - go through c166_reg_offset_addr so EXTP/EXTS overrides
+# and DPP-paged translation are honoured (segment(0, reg) ignored both).
+RwnIndW: [rwn] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:2 addr; }
+RwnIndWP: [rwn+] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:2 addr; rwn=rwn+2; }
+RwmIndW: [rwm] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; }
+RwmIndWP: [rwm+] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; rwm=rwm+2; }
+RwmIndWM: [-rwm] is rwm { rwm=rwm-2; local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:2 addr; }
 RwmIndWOff: [rwm+DataImmW] is rwm; DataImmW { local addr:3 = c166_reg_offset_addr(rwm, DataImmW); export *[ram]:2 addr; }
 
 # r0 (stack pointer) - direct access for byte operations (define first, then constrain)
@@ -284,12 +285,12 @@ RwmIndBP: [rwm+] is rwm & rwm=0 { local addr:2 = rwm; rwm=rwm+1; export *:1 addr
 RwmIndBM: [-rwm] is rwm & rwm=0 { rwm=rwm-1; export *:1 rwm; }
 RwmIndBOff: [rwm+DataImmW] is rwm & rwm=0; DataImmW { local off:2 = rwm + DataImmW; export *[ram]:1 off; }
 
-# Other registers - use segment(0, reg) for byte operations
-RwnIndB: [rwn] is rwn { local addr:3 = segment(0:2, rwn); export *:1 addr; }
-RwnIndBP: [rwn+] is rwn { local addr:3 = segment(0:2, rwn); export *:1 addr; rwn=rwn+1; }
-RwmIndB: [rwm] is rwm { local addr:3 = segment(0:2, rwm); export *:1 addr; }
-RwmIndBP: [rwm+] is rwm { local addr:3 = segment(0:2, rwm); export *:1 addr; rwm=rwm+1; }
-RwmIndBM: [-rwm] is rwm { rwm=rwm-1; local addr:3 = segment(0:2, rwm); export *:1 addr; }
+# Other registers - go through c166_reg_offset_addr (see word variant above).
+RwnIndB: [rwn] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:1 addr; }
+RwnIndBP: [rwn+] is rwn { local addr:3 = c166_reg_offset_addr(rwn, 0:2); export *:1 addr; rwn=rwn+1; }
+RwmIndB: [rwm] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; }
+RwmIndBP: [rwm+] is rwm { local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; rwm=rwm+1; }
+RwmIndBM: [-rwm] is rwm { rwm=rwm-1; local addr:3 = c166_reg_offset_addr(rwm, 0:2); export *:1 addr; }
 RwmIndBOff: [rwm+DataImmW] is rwm; DataImmW { local addr:3 = c166_reg_offset_addr(rwm, DataImmW); export *[ram]:1 addr; }
 
 RWnRWmEqual: is rwn=rwm { local NOP:1 = 0; }

--- a/data/languages/c166.sinc
+++ b/data/languages/c166.sinc
@@ -32,8 +32,10 @@ define context contextreg
 	ExtsEn  = (5,5)
 	Extp    = (6,21)
 	Exts    = (22, 29)
-	ExtpReg = (30, 33)  # Register index for register-based EXTP (0-15, 0xF = immediate)
-	ExtsReg = (34, 37)  # Register index for register-based EXTS (0-15, 0xF = immediate)
+	ExtpReg = (30, 33)  # Register index for register-based EXTP (0-15) when ExtpRegMode=1
+	ExtsReg = (34, 37)  # Register index for register-based EXTS (0-15) when ExtsRegMode=1
+	ExtpRegMode = (38, 38)  # 1 = ExtpReg holds GP register index; 0 = immediate-mode (Extp = page)
+	ExtsRegMode = (39, 39)  # 1 = ExtsReg holds GP register index; 0 = immediate-mode (Exts = segment)
 ;
 
 @define PSW_N "PSW[0,1]"
@@ -244,11 +246,11 @@ BitoffAddrZ: z_2 is z=0xf & z_2 { export z_2; }
 
 SetAtomic: "#"^range is irang2 [ range = irang2 + 1; Counter = range; globalset(inst_start, Counter); ] { local tmp:1 = range:1; export tmp; }
 SetExtr: SetAtomic is SetAtomic [ ExtrEn = 1; globalset(inst_start, ExtrEn); ] { local NOP:1 = 0; }
-SetExtpInd: rwm, SetAtomic is rwm & SetAtomic [ ExtpEn = 1; globalset(inst_start, ExtpEn); Extp=0; globalset(inst_start, Extp); ExtpReg=rwm; globalset(inst_start, ExtpReg); ] { local NOP:1 = 0; }
-SetExtp: page, SetAtomic is rwm=0 & SetAtomic; page [ ExtpEn = 1; globalset(inst_start, ExtpEn); Extp=page; globalset(inst_start, Extp); ExtpReg=0xF; globalset(inst_start, ExtpReg); ] { local NOP:1 = 0; }
-SetExtsInd: rwm, SetAtomic is rwm & SetAtomic [ ExtsEn = 1; globalset(inst_start, ExtsEn); Exts=0; globalset(inst_start, Exts); ExtsReg=rwm; globalset(inst_start, ExtsReg); ] { local NOP:1 = 0; }
-SetExts: seg, SetAtomic is rwm = 0 & SetAtomic; seg [ ExtsEn = 1; globalset(inst_start, ExtsEn); Exts=seg; globalset(inst_start, Exts); ExtsReg=0xF; globalset(inst_start, ExtsReg); ] { local NOP:1 = 0; }
-ExtCountDec: is Counter=0 [ ExtrEn=0; globalset(inst_start, ExtrEn); ExtpEn=0; globalset(inst_start, ExtpEn); ExtsEn=0; globalset(inst_start, ExtsEn); ExtpReg=0xF; globalset(inst_start, ExtpReg); ExtsReg=0xF; globalset(inst_start, ExtsReg); ] { local NOP:1 = 0; }
+SetExtpInd: rwm, SetAtomic is rwm & SetAtomic [ ExtpEn = 1; globalset(inst_start, ExtpEn); Extp=0; globalset(inst_start, Extp); ExtpReg=rwm; globalset(inst_start, ExtpReg); ExtpRegMode=1; globalset(inst_start, ExtpRegMode); ] { local NOP:1 = 0; }
+SetExtp: page, SetAtomic is rwm=0 & SetAtomic; page [ ExtpEn = 1; globalset(inst_start, ExtpEn); Extp=page; globalset(inst_start, Extp); ExtpReg=0; globalset(inst_start, ExtpReg); ExtpRegMode=0; globalset(inst_start, ExtpRegMode); ] { local NOP:1 = 0; }
+SetExtsInd: rwm, SetAtomic is rwm & SetAtomic [ ExtsEn = 1; globalset(inst_start, ExtsEn); Exts=0; globalset(inst_start, Exts); ExtsReg=rwm; globalset(inst_start, ExtsReg); ExtsRegMode=1; globalset(inst_start, ExtsRegMode); ] { local NOP:1 = 0; }
+SetExts: seg, SetAtomic is rwm = 0 & SetAtomic; seg [ ExtsEn = 1; globalset(inst_start, ExtsEn); Exts=seg; globalset(inst_start, Exts); ExtsReg=0; globalset(inst_start, ExtsReg); ExtsRegMode=0; globalset(inst_start, ExtsRegMode); ] { local NOP:1 = 0; }
+ExtCountDec: is Counter=0 [ ExtrEn=0; globalset(inst_start, ExtrEn); ExtpEn=0; globalset(inst_start, ExtpEn); ExtsEn=0; globalset(inst_start, ExtsEn); ExtpReg=0; globalset(inst_start, ExtpReg); ExtsReg=0; globalset(inst_start, ExtsReg); ExtpRegMode=0; globalset(inst_start, ExtpRegMode); ExtsRegMode=0; globalset(inst_start, ExtsRegMode); ] { local NOP:1 = 0; }
 ExtCountDec: is Counter!=0 [ Counter = Counter - 1; globalset(inst_start, Counter);] { local NOP:1 = 0; }
 
 LongMemAddrW: mem is mem { local tmp:3 = GetPagedOffset(mem:2); export *:2tmp; }

--- a/src/main/java/ghidrainfineon/C166AddressAnalyzer.java
+++ b/src/main/java/ghidrainfineon/C166AddressAnalyzer.java
@@ -67,6 +67,8 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 	private Register extsEn;
 	private Register extpReg;
 	private Register extsReg;
+	private Register extpRegMode;
+	private Register extsRegMode;
 
 	public C166AddressAnalyzer() {
 		super(PROCESSOR_NAME);
@@ -134,6 +136,8 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 		extsEn = program.getRegister("ExtsEn");
 		extpReg = program.getRegister("ExtpReg");
 		extsReg = program.getRegister("ExtsReg");
+		extpRegMode = program.getRegister("ExtpRegMode");
+		extsRegMode = program.getRegister("ExtsRegMode");
 	}
 
 	private class C166ContextEvaluator extends ConstantPropagationContextEvaluator {
@@ -200,7 +204,7 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 			
 			// Check for EXTS override first (segment-based, uses full 16-bit offset)
 			if (isContextEnabled(progCtx, instrAddr, extsEn)) {
-				Long segment = getExtValue(context, progCtx, instrAddr, exts, extsReg);
+				Long segment = getExtValue(context, progCtx, instrAddr, exts, extsReg, extsRegMode);
 				if (segment != null) {
 					segment = segment & 0xFFL;
 					long resolved = (segment << 16) | (raw & 0xFFFFL);
@@ -217,7 +221,7 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 			
 			// Check for EXTP override (page-based, uses 14-bit offset)
 			if (isContextEnabled(progCtx, instrAddr, extpEn)) {
-				Long page = getExtValue(context, progCtx, instrAddr, extp, extpReg);
+				Long page = getExtValue(context, progCtx, instrAddr, extp, extpReg, extpRegMode);
 				if (page != null) {
 					page = page & 0x3FFL;
 					long innerOffset = raw & PAGE_MASK;
@@ -274,28 +278,36 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 
 		/**
 		 * Get the EXTP/EXTS value, checking if it's register-based or immediate.
+		 *
+		 * Mode is decided by the dedicated 1-bit context register
+		 * (ExtpRegMode/ExtsRegMode). The earlier sentinel-based scheme
+		 * (regIdx == 0xF) collided with the legitimate register index for
+		 * r15.
 		 */
 		private Long getExtValue(VarnodeContext varnodeCtx, ProgramContext progCtx, Address addr,
-				Register immReg, Register regIdxReg) {
-			// Check if register-based (regIdx != 0xF)
-			if (regIdxReg != null) {
-				BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
-				if (regIdx != null) {
-					int idx = regIdx.intValue() & 0xF;
-					if (idx != 0xF && idx < gpRegisters.length) {
-						// Register-based: look up the GP register value from VarnodeContext
-						Register gpReg = gpRegisters[idx];
-						if (gpReg != null) {
-							BigInteger gpValue = varnodeCtx.getValue(gpReg, false);
-							if (gpValue != null) {
-								return gpValue.longValue();
+				Register immReg, Register regIdxReg, Register regModeReg) {
+			if (regModeReg != null) {
+				BigInteger regMode = progCtx.getValue(regModeReg, addr, false);
+				if (regMode != null && regMode.equals(BigInteger.ONE)) {
+					if (regIdxReg != null) {
+						BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
+						if (regIdx != null) {
+							int idx = regIdx.intValue() & 0xF;
+							if (idx < gpRegisters.length) {
+								Register gpReg = gpRegisters[idx];
+								if (gpReg != null) {
+									BigInteger gpValue = varnodeCtx.getValue(gpReg, false);
+									if (gpValue != null) {
+										return gpValue.longValue();
+									}
+								}
 							}
 						}
-						return null;  // Register-based but value unknown
 					}
+					return null;  // Register-based but value unknown
 				}
 			}
-			
+
 			// Immediate mode: use the context register value from ProgramContext
 			if (immReg != null) {
 				BigInteger immValue = progCtx.getValue(immReg, addr, false);
@@ -303,7 +315,7 @@ public class C166AddressAnalyzer extends ConstantPropagationAnalyzer {
 					return immValue.longValue();
 				}
 			}
-			
+
 			return null;
 		}
 	}

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -187,7 +187,7 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		// 1. EXTP override (page-shift = 14)
 		Long extpEnVal = readContext(progCtx, "ExtpEn", addr);
 		if (extpEnVal != null && extpEnVal == 1L) {
-			EffectiveExt extp = readEffectiveExt(program, addr, "Extp", "ExtpReg");
+			EffectiveExt extp = readEffectiveExt(program, addr, "Extp", "ExtpReg", "ExtpRegMode");
 			if (extp != null) {
 				if (extp.isImmediate()) {
 					return emitPagedSegment(addr, reg, offset & 0x3FFF, extp.immValue & 0x3FFL,
@@ -202,7 +202,7 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		// 2. EXTS override (segment shift = 16 bits, full offset preserved)
 		Long extsEnVal = readContext(progCtx, "ExtsEn", addr);
 		if (extsEnVal != null && extsEnVal == 1L) {
-			EffectiveExt exts = readEffectiveExt(program, addr, "Exts", "ExtsReg");
+			EffectiveExt exts = readEffectiveExt(program, addr, "Exts", "ExtsReg", "ExtsRegMode");
 			if (exts != null) {
 				if (exts.isImmediate()) {
 					return emitSegmentShift16(addr, reg, offset & 0xFFFFL, exts.immValue & 0xFFL,
@@ -419,25 +419,35 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 
 	/**
-	 * Resolve the EXTP/EXTS at addr to either an immediate value (regIdx = 0xF)
-	 * or a GP register reference (regIdx = 0..14).
+	 * Resolve EXTP/EXTS at addr.
+	 *
+	 * The disambiguation between register-mode and immediate-mode comes from
+	 * the dedicated 1-bit context register (ExtpRegMode / ExtsRegMode).
+	 * The earlier sentinel-based scheme (regIdx == 0xF -> immediate) collided
+	 * with the legitimate register index for r15: any `extp r15,#1` was
+	 * silently treated as immediate-mode and the register-mode pcode never
+	 * fired, leaving phantom refs at the un-paged 16-bit offset.
 	 */
 	private EffectiveExt readEffectiveExt(Program program, Address addr,
-			String immRegName, String regIdxName) {
+			String immRegName, String regIdxName, String regModeName) {
 		ProgramContext progCtx = program.getProgramContext();
 
-		Register regIdxReg = progCtx.getRegister(regIdxName);
-		if (regIdxReg != null) {
-			BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
-			if (regIdx != null) {
-				int idx = regIdx.intValue() & 0xF;
-				if (idx != 0xF) {
-					Register gpReg = program.getRegister("r" + idx);
-					if (gpReg != null) {
-						return EffectiveExt.registerMode(gpReg);
+		Register regModeReg = progCtx.getRegister(regModeName);
+		if (regModeReg != null) {
+			BigInteger regMode = progCtx.getValue(regModeReg, addr, false);
+			if (regMode != null && regMode.equals(BigInteger.ONE)) {
+				Register regIdxReg = progCtx.getRegister(regIdxName);
+				if (regIdxReg != null) {
+					BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
+					if (regIdx != null) {
+						int idx = regIdx.intValue() & 0xF;
+						Register gpReg = program.getRegister("r" + idx);
+						if (gpReg != null) {
+							return EffectiveExt.registerMode(gpReg);
+						}
 					}
-					return null;
 				}
+				return null;
 			}
 		}
 

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -184,12 +184,16 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 
 		ProgramContext progCtx = program.getProgramContext();
 
-		// 1. EXTP override
+		// 1. EXTP override (page-shift = 14)
 		Long extpEnVal = readContext(progCtx, "ExtpEn", addr);
 		if (extpEnVal != null && extpEnVal == 1L) {
-			Long extpPage = readEffectiveExtValue(program, addr, "Extp", "ExtpReg");
-			if (extpPage != null) {
-				return emitPagedSegment(addr, reg, offset & 0x3FFF, extpPage & 0x3FFL,
+			EffectiveExt extp = readEffectiveExt(program, addr, "Extp", "ExtpReg");
+			if (extp != null) {
+				if (extp.isImmediate()) {
+					return emitPagedSegment(addr, reg, offset & 0x3FFF, extp.immValue & 0x3FFL,
+							output, constSpace, uniqueSpace, uniqueOffset);
+				}
+				return emitShiftViaReg(addr, reg, offset & 0x3FFFL, extp.gpRegister, 14,
 						output, constSpace, uniqueSpace, uniqueOffset);
 			}
 			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
@@ -198,9 +202,13 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		// 2. EXTS override (segment shift = 16 bits, full offset preserved)
 		Long extsEnVal = readContext(progCtx, "ExtsEn", addr);
 		if (extsEnVal != null && extsEnVal == 1L) {
-			Long extsSeg = readEffectiveExtValue(program, addr, "Exts", "ExtsReg");
-			if (extsSeg != null) {
-				return emitSegmentShift16(addr, reg, offset & 0xFFFFL, extsSeg & 0xFFL,
+			EffectiveExt exts = readEffectiveExt(program, addr, "Exts", "ExtsReg");
+			if (exts != null) {
+				if (exts.isImmediate()) {
+					return emitSegmentShift16(addr, reg, offset & 0xFFFFL, exts.immValue & 0xFFL,
+							output, constSpace, uniqueSpace, uniqueOffset);
+				}
+				return emitShiftViaReg(addr, reg, offset & 0xFFFFL, exts.gpRegister, 16,
 						output, constSpace, uniqueSpace, uniqueOffset);
 			}
 			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
@@ -297,6 +305,60 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 
 	/**
+	 * Emit `output = (zext(gpReg) << shiftAmount) + zext(reg + maskedOffset)`
+	 * for register-mode EXTP (shift = 14) and EXTS (shift = 16).
+	 *
+	 * The segment/page value lives in `gpReg` at runtime, not in the
+	 * ProgramContext, so it can't be folded into a constant at pcode-gen
+	 * time. Emitting the GP register as a varnode lets the symbolic
+	 * propagator resolve it during analysis: when the immediately
+	 * preceding `mov gpReg,#imm` is constant-propagated, the address
+	 * collapses to a concrete 24-bit target and a real reference is
+	 * created (e.g. for `mov r5,#0x14; exts r5,#1; mov r5,[r4]` the
+	 * target becomes 0x14_0000 + r4).
+	 *
+	 * Carry-into-segment-bit caveat: same as emitSegmentShift16 /
+	 * emitPagedSegment — INT_ADD only differs from INT_OR if the in-page
+	 * sum overflows the page window. Compiler-generated `[reg+#imm]`
+	 * stays inside, so the carry path is unreachable for valid code.
+	 */
+	private PcodeOp[] emitShiftViaReg(Address addr, Varnode reg, long maskedOffset,
+			Register gpReg, int shiftAmount,
+			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
+		int seqnum = 0;
+		PcodeOp[] ops = new PcodeOp[5];
+
+		Varnode gpVarnode = new Varnode(gpReg.getAddress(), gpReg.getMinimumByteSize());
+
+		// 1. sum:2 = reg + maskedOffset
+		Varnode offsetConst = new Varnode(constSpace.getAddress(maskedOffset), 2);
+		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
+		// 2. zsum:3 = zext(sum)
+		Varnode zsum = new Varnode(uniqueSpace.getAddress(uniqueOffset + 4), 3);
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, zsum);
+
+		// 3. zgpReg:3 = zext(gpReg)
+		Varnode zgpReg = new Varnode(uniqueSpace.getAddress(uniqueOffset + 8), 3);
+		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT,
+				new Varnode[] { gpVarnode }, zgpReg);
+
+		// 4. shifted:3 = zgpReg << shiftAmount
+		Varnode shiftConst = new Varnode(constSpace.getAddress(shiftAmount), 4);
+		Varnode shifted = new Varnode(uniqueSpace.getAddress(uniqueOffset + 12), 3);
+		ops[3] = new PcodeOp(addr, seqnum++, PcodeOp.INT_LEFT,
+				new Varnode[] { zgpReg, shiftConst }, shifted);
+
+		// 5. output:3 = zsum + shifted
+		ops[4] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { zsum, shifted }, output);
+
+		return ops;
+	}
+
+	/**
 	 * Fallback when no DPP/EXTP/EXTS context is available: emit
 	 * `output = zext((reg + offset) & 0xFFFF)`. Reference target then
 	 * matches the disassembly operand and avoids creating phantom xrefs
@@ -324,11 +386,43 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 
 	/**
-	 * Resolve the actual EXTP/EXTS value at addr — immediate (Extp/Exts context
-	 * register, regIdx = 0xF) or register-mode (Extp/Exts is irrelevant, look up
-	 * GP register named via ExtpReg/ExtsReg).
+	 * Resolved EXTP/EXTS at a given instruction. Either the immediate value
+	 * (encoded directly in the EXTP/EXTS instruction) or the GP register that
+	 * carries the segment/page at runtime (register-mode: `extp Rwm,#irang2`).
+	 *
+	 * Register-mode cannot be reduced to a single value at pcode-generation
+	 * time because GP register contents do not live in the ProgramContext —
+	 * they're propagated by the analyzer/decompiler at analysis time. The
+	 * register reference is therefore preserved and emitted into the pcode
+	 * so the symbolic propagator resolves it later.
 	 */
-	private Long readEffectiveExtValue(Program program, Address addr,
+	private static class EffectiveExt {
+		final Long immValue;
+		final Register gpRegister;
+
+		private EffectiveExt(Long immValue, Register gpRegister) {
+			this.immValue = immValue;
+			this.gpRegister = gpRegister;
+		}
+
+		static EffectiveExt immediate(long value) {
+			return new EffectiveExt(value, null);
+		}
+
+		static EffectiveExt registerMode(Register gpReg) {
+			return new EffectiveExt(null, gpReg);
+		}
+
+		boolean isImmediate() {
+			return immValue != null;
+		}
+	}
+
+	/**
+	 * Resolve the EXTP/EXTS at addr to either an immediate value (regIdx = 0xF)
+	 * or a GP register reference (regIdx = 0..14).
+	 */
+	private EffectiveExt readEffectiveExt(Program program, Address addr,
 			String immRegName, String regIdxName) {
 		ProgramContext progCtx = program.getProgramContext();
 
@@ -340,8 +434,7 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 				if (idx != 0xF) {
 					Register gpReg = program.getRegister("r" + idx);
 					if (gpReg != null) {
-						BigInteger gpValue = progCtx.getValue(gpReg, addr, false);
-						return gpValue == null ? null : gpValue.longValue();
+						return EffectiveExt.registerMode(gpReg);
 					}
 					return null;
 				}
@@ -351,7 +444,7 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		Register immReg = progCtx.getRegister(immRegName);
 		if (immReg == null) return null;
 		BigInteger v = progCtx.getValue(immReg, addr, false);
-		return v == null ? null : v.longValue();
+		return v == null ? null : EffectiveExt.immediate(v.longValue());
 	}
 
 	/**

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -81,23 +81,42 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		AddressSpace uniqueSpace = language.getAddressFactory().getUniqueSpace();
 		
 		long offset = offsetInput.getOffset();
-		
+
 		// Use instruction address to create unique temp addresses
 		long uniqueOffset = uniqueBase + ((currentAddr.getOffset() & 0xFFFFFF) >> 1) * 16;
-		
-		if (offset < STACK_THRESHOLD && isStackPointer(regInput)) {
-			// Stack access with r0: emit direct zext without segment() for stack analysis
+
+		// EXTP / EXTS overrides take precedence over the stack-pointer
+		// special case. With a segment override active in front of a
+		// register-indirect access the target is memory-mapped hardware,
+		// never the stack; without honouring the override the access
+		// collapses to the low-memory image of the register and creates
+		// phantom references near 0x000000.
+		ProgramContext progCtx = program.getProgramContext();
+		boolean extActive = isContextOne(progCtx, "ExtpEn", currentAddr)
+				|| isContextOne(progCtx, "ExtsEn", currentAddr);
+
+		if (!extActive && offset < STACK_THRESHOLD && isStackPointer(regInput)) {
+			// Stack access with r0 and no segment override: emit direct
+			// zext for stack analysis.
 			return emitDirectStackAccess(currentAddr, regInput, offset, output,
 					constSpace, uniqueSpace, uniqueOffset);
-		} else if (offset < STACK_THRESHOLD) {
-			// Small offset but not r0: use segment(0, reg + offset)
-			return emitSimpleSegment(currentAddr, regInput, offset, output, 
-					constSpace, uniqueSpace, uniqueOffset);
-		} else {
-			// DPP-paged access: segment(dpp, reg + (offset & 0x3FFF))
-			return emitDppSegment(program, currentAddr, regInput, offset, output,
-					constSpace, uniqueSpace, uniqueOffset);
 		}
+
+		// All remaining cases — register-indirect with no offset, with
+		// small offset on a non-stack register, or any larger offset, and
+		// in particular every access with EXTP/EXTS active — go through
+		// emitDppSegment, which already resolves EXTP first, then EXTS,
+		// then the matching DPP, with a raw-offset fall-through when
+		// none of those are known.
+		return emitDppSegment(program, currentAddr, regInput, offset, output,
+				constSpace, uniqueSpace, uniqueOffset);
+	}
+
+	private boolean isContextOne(ProgramContext progCtx, String regName, Address addr) {
+		Register r = progCtx.getRegister(regName);
+		if (r == null) return false;
+		BigInteger v = progCtx.getValue(r, addr, false);
+		return v != null && v.equals(BigInteger.ONE);
 	}
 	
 	/**

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -200,29 +200,59 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 
 	/**
-	 * Emit `output = segment(page, reg + maskedOffset)` (page-shift = 14).
+	 * Emit `output = (page << 14) + zext(reg + maskedOffset)` for paged access.
+	 *
+	 * The earlier implementation emitted `segment(page, reg + maskedOffset)`,
+	 * which the segment() pcodeop unfolds as `(page << 14) | sum`. The
+	 * decompiler can't reduce a bitwise OR across an arithmetic sum, so
+	 * accesses like `*(page * 0x4000 + base + index)` rendered with the raw
+	 * 16-bit base offset (e.g. `*(byte *)(uVar3 * 10 + 0x30AC)` instead of
+	 * `handle_table[uVar3]`).
+	 *
+	 * Switching to plain INT_ADD with a constant page contribution lets the
+	 * decompiler fold the constant page+base into a single resolvable
+	 * address, recovering symbol references.
+	 *
+	 * Correctness: + and | only differ when sum overflows the 14-bit page
+	 * window (sum >= 0x4000). Since maskedOffset was already AND-ed with
+	 * 0x3FFF and reg-based indexing in compiler-generated code stays well
+	 * inside the page (cross-page indexing requires absolute long-mem
+	 * encoding, not [reg+#imm]), the carry path is unreachable for valid
+	 * code. Pathological assembler that writes [reg+#imm] with reg + imm
+	 * spilling into the page bits would already be semantically broken at
+	 * the source — and the disassembly operand would mislead just as much.
 	 */
 	private PcodeOp[] emitPagedSegment(Address addr, Varnode reg, long maskedOffset, long page,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
 		int seqnum = 0;
 		PcodeOp[] ops = new PcodeOp[2];
 
-		Varnode offsetConst = new Varnode(constSpace.getAddress(maskedOffset), 2);
-		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
-		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
-				new Varnode[] { reg, offsetConst }, sum);
+		// Pre-fold the page contribution and the in-page offset into a single
+		// 24-bit constant. Putting the absolute address (e.g. 0x130AC) directly
+		// into the pcode lets the decompiler match it against the symbol table
+		// without further constant propagation across a zero-extend.
+		long absBase = ((page & 0x3FFL) << 14) | (maskedOffset & 0x3FFFL);
 
-		Varnode useropId = new Varnode(constSpace.getAddress(segmentUseropIndex), 4);
-		Varnode pageConst = new Varnode(constSpace.getAddress(page), 2);
-		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.CALLOTHER,
-				new Varnode[] { useropId, pageConst, sum }, output);
+		// 1. zreg:3 = zext(reg)
+		Varnode zreg = new Varnode(uniqueSpace.getAddress(uniqueOffset), 3);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT,
+				new Varnode[] { reg }, zreg);
+
+		// 2. output:3 = zreg + absBase
+		Varnode baseConst = new Varnode(constSpace.getAddress(absBase), 3);
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { zreg, baseConst }, output);
 
 		return ops;
 	}
 
 	/**
-	 * Emit `output = (segment << 16) | (reg + offset)` for EXTS-overridden access.
-	 * Cannot use the segment() pcodeop here because it always shifts by 14.
+	 * Emit `output = (segment << 16) + zext(reg + offset)` for EXTS-overridden
+	 * access. Same arithmetic-vs-bitwise tradeoff as emitPagedSegment — the
+	 * 16-bit register+offset never overflows into the segment bits in valid
+	 * compiler-generated code (segment crossing requires explicit handling).
+	 * Using INT_ADD instead of INT_OR keeps the address foldable for the
+	 * decompiler so symbol references survive.
 	 */
 	private PcodeOp[] emitSegmentShift16(Address addr, Varnode reg, long offset, long segment,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
@@ -239,9 +269,9 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 		Varnode zsum = new Varnode(uniqueSpace.getAddress(uniqueOffset + 4), 3);
 		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, zsum);
 
-		// 3. output:3 = zsum | (segment << 16)
-		Varnode segConst = new Varnode(constSpace.getAddress(segment << 16), 3);
-		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_OR,
+		// 3. output:3 = zsum + (segment << 16)
+		Varnode segConst = new Varnode(constSpace.getAddress((segment & 0xFFL) << 16), 3);
+		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
 				new Varnode[] { zsum, segConst }, output);
 
 		return ops;

--- a/src/main/java/ghidrainfineon/RegOffsetAddr.java
+++ b/src/main/java/ghidrainfineon/RegOffsetAddr.java
@@ -27,6 +27,7 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.lang.*;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.ProgramContext;
 import ghidra.program.model.pcode.*;
 
 /**
@@ -144,37 +145,166 @@ public class RegOffsetAddr extends InjectPayloadCallother {
 	}
 	
 	/**
-	 * Emit segment(dpp, reg + (offset & 0x3FFF)) for DPP-paged access
+	 * Emit a paged-memory address calc for [rwm + #imm] when imm >= STACK_THRESHOLD.
+	 *
+	 * Resolution priority — same hierarchy as the C166 hardware:
+	 *   1. EXTP active + page known   -> segment(Extp, reg + (offset & 0x3FFF))
+	 *   2. EXTS active + segment known -> emit (Exts << 16) | (reg + offset)  (no segment(),
+	 *                                     because the segment() pcodeop is page-shift only)
+	 *   3. DPP[index of offset top bits] known -> segment(DPP, reg + (offset & 0x3FFF))
+	 *   4. None known -> raw fallback: zext((reg + offset) & 0xFFFF) into the 3-byte address.
+	 *
+	 * The previous fallback `dppValue = dppIndex` produced phantom xrefs in the
+	 * 0x0000..0xFFFF window because dppIndex is just the top two bits of offset
+	 * (0..3) and segment(0..3, x) maps near zero, never to the binary's loaded
+	 * pages. The raw fallback at least keeps the encoded address in sync with
+	 * what the disassembly listing renders.
 	 */
-	private PcodeOp[] emitDppSegment(Program program, Address addr, Varnode reg, long offset, 
+	private PcodeOp[] emitDppSegment(Program program, Address addr, Varnode reg, long offset,
 			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
-		
-		// Get DPP value based on offset's upper 2 bits
+
+		ProgramContext progCtx = program.getProgramContext();
+
+		// 1. EXTP override
+		Long extpEnVal = readContext(progCtx, "ExtpEn", addr);
+		if (extpEnVal != null && extpEnVal == 1L) {
+			Long extpPage = readEffectiveExtValue(program, addr, "Extp", "ExtpReg");
+			if (extpPage != null) {
+				return emitPagedSegment(addr, reg, offset & 0x3FFF, extpPage & 0x3FFL,
+						output, constSpace, uniqueSpace, uniqueOffset);
+			}
+			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+		}
+
+		// 2. EXTS override (segment shift = 16 bits, full offset preserved)
+		Long extsEnVal = readContext(progCtx, "ExtsEn", addr);
+		if (extsEnVal != null && extsEnVal == 1L) {
+			Long extsSeg = readEffectiveExtValue(program, addr, "Exts", "ExtsReg");
+			if (extsSeg != null) {
+				return emitSegmentShift16(addr, reg, offset & 0xFFFFL, extsSeg & 0xFFL,
+						output, constSpace, uniqueSpace, uniqueOffset);
+			}
+			return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+		}
+
+		// 3. DPP-paged (default)
 		int dppIndex = (int) ((offset >> 14) & 3);
 		Long dppValue = getDppValue(program, addr, dppIndex);
-		if (dppValue == null) {
-			dppValue = (long) dppIndex; // Fallback
+		if (dppValue != null) {
+			return emitPagedSegment(addr, reg, offset & 0x3FFF, dppValue,
+					output, constSpace, uniqueSpace, uniqueOffset);
 		}
-		
-		long maskedOffset = offset & 0x3FFF;
-		
+
+		// 4. Nothing known — raw 16-bit fallback
+		return emitRawFallback(addr, reg, offset, output, constSpace, uniqueSpace, uniqueOffset);
+	}
+
+	/**
+	 * Emit `output = segment(page, reg + maskedOffset)` (page-shift = 14).
+	 */
+	private PcodeOp[] emitPagedSegment(Address addr, Varnode reg, long maskedOffset, long page,
+			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
 		int seqnum = 0;
 		PcodeOp[] ops = new PcodeOp[2];
-		
-		// 1. sum = reg + maskedOffset
+
 		Varnode offsetConst = new Varnode(constSpace.getAddress(maskedOffset), 2);
 		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
-		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD, new Varnode[] { reg, offsetConst }, sum);
-		
-		// 2. output = segment(dpp, sum)
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
 		Varnode useropId = new Varnode(constSpace.getAddress(segmentUseropIndex), 4);
-		Varnode dppConst = new Varnode(constSpace.getAddress(dppValue), 2);
+		Varnode pageConst = new Varnode(constSpace.getAddress(page), 2);
 		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.CALLOTHER,
-				new Varnode[] { useropId, dppConst, sum }, output);
-		
+				new Varnode[] { useropId, pageConst, sum }, output);
+
 		return ops;
 	}
-	
+
+	/**
+	 * Emit `output = (segment << 16) | (reg + offset)` for EXTS-overridden access.
+	 * Cannot use the segment() pcodeop here because it always shifts by 14.
+	 */
+	private PcodeOp[] emitSegmentShift16(Address addr, Varnode reg, long offset, long segment,
+			Varnode output, AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
+		int seqnum = 0;
+		PcodeOp[] ops = new PcodeOp[3];
+
+		// 1. sum:2 = reg + offset
+		Varnode offsetConst = new Varnode(constSpace.getAddress(offset), 2);
+		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
+		// 2. zsum:3 = zext(sum)
+		Varnode zsum = new Varnode(uniqueSpace.getAddress(uniqueOffset + 4), 3);
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, zsum);
+
+		// 3. output:3 = zsum | (segment << 16)
+		Varnode segConst = new Varnode(constSpace.getAddress(segment << 16), 3);
+		ops[2] = new PcodeOp(addr, seqnum++, PcodeOp.INT_OR,
+				new Varnode[] { zsum, segConst }, output);
+
+		return ops;
+	}
+
+	/**
+	 * Fallback when no DPP/EXTP/EXTS context is available: emit
+	 * `output = zext((reg + offset) & 0xFFFF)`. Reference target then
+	 * matches the disassembly operand and avoids creating phantom xrefs
+	 * in the 0x0000..0xFFFF window.
+	 */
+	private PcodeOp[] emitRawFallback(Address addr, Varnode reg, long offset, Varnode output,
+			AddressSpace constSpace, AddressSpace uniqueSpace, long uniqueOffset) {
+		int seqnum = 0;
+		PcodeOp[] ops = new PcodeOp[2];
+
+		Varnode offsetConst = new Varnode(constSpace.getAddress(offset & 0xFFFFL), 2);
+		Varnode sum = new Varnode(uniqueSpace.getAddress(uniqueOffset), 2);
+		ops[0] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ADD,
+				new Varnode[] { reg, offsetConst }, sum);
+
+		ops[1] = new PcodeOp(addr, seqnum++, PcodeOp.INT_ZEXT, new Varnode[] { sum }, output);
+		return ops;
+	}
+
+	private Long readContext(ProgramContext progCtx, String regName, Address addr) {
+		Register r = progCtx.getRegister(regName);
+		if (r == null) return null;
+		BigInteger v = progCtx.getValue(r, addr, false);
+		return v == null ? null : v.longValue();
+	}
+
+	/**
+	 * Resolve the actual EXTP/EXTS value at addr — immediate (Extp/Exts context
+	 * register, regIdx = 0xF) or register-mode (Extp/Exts is irrelevant, look up
+	 * GP register named via ExtpReg/ExtsReg).
+	 */
+	private Long readEffectiveExtValue(Program program, Address addr,
+			String immRegName, String regIdxName) {
+		ProgramContext progCtx = program.getProgramContext();
+
+		Register regIdxReg = progCtx.getRegister(regIdxName);
+		if (regIdxReg != null) {
+			BigInteger regIdx = progCtx.getValue(regIdxReg, addr, false);
+			if (regIdx != null) {
+				int idx = regIdx.intValue() & 0xF;
+				if (idx != 0xF) {
+					Register gpReg = program.getRegister("r" + idx);
+					if (gpReg != null) {
+						BigInteger gpValue = progCtx.getValue(gpReg, addr, false);
+						return gpValue == null ? null : gpValue.longValue();
+					}
+					return null;
+				}
+			}
+		}
+
+		Register immReg = progCtx.getRegister(immRegName);
+		if (immReg == null) return null;
+		BigInteger v = progCtx.getValue(immReg, addr, false);
+		return v == null ? null : v.longValue();
+	}
+
 	/**
 	 * Get the DPP register value for the given index
 	 */


### PR DESCRIPTION
Summary
Two related fixes that finish the EXTP/EXTS register-mode resolution started in #32:

Emit pcode for register-mode overrides so the symbolic propagator can resolve the page/segment from the GP register at analysis time.
Replace the 0xF sentinel in Ext{p,s}Reg with a dedicated 1-bit context register — the old sentinel collided with the legitimate index for r15.
Both commits ship together because the first one is half-functional alone: it works for r0..r14 but silently does nothing for r15, which is the page-register that compilers actually pick most often (Keil C166 uses r15 as the DPP-page anchor for r14-based DiagState pointers, for example).

Background
PR #32 introduced readEffectiveExtValue in RegOffsetAddr to honour EXTP/EXTS. For register-mode (e.g. extp r15,#1; mov [r14+#0x30],r6) it tried to look up the GP register's runtime value through ProgramContext.getValue(gpReg, …), which always returns null because GP registers are not context registers. The path silently fell through to the raw 16-bit fallback, so the reference was created at [r14+#0x30] (un-paged) instead of at the real paged target.

While fixing this I noticed a second, latent bug: the SLEIGH macros encode register-mode as Ext{p,s}Reg = rwm and immediate-mode as Ext{p,s}Reg = 0xF. But 0xF is also the legitimate 4-bit index for r15. Any extp r15,#1 was therefore treated as immediate-mode and the register-mode pcode never fired — a bug the first commit alone wouldn't fix.

Changes
Commit 1: emit pcode for register-mode

RegOffsetAddr.java: split readEffectiveExtValue into an EffectiveExt result type that distinguishes immediate-mode (long page/segment value) from register-mode (a Register reference).
New emitShiftViaReg(reg, gpReg, shiftAmount, …) emits output = (zext(gpReg) << shiftAmount) + zext(reg + offset) so the propagator resolves the GP register value during constant analysis.
Used for both EXTP (shift = 14) and EXTS (shift = 16).
Commit 2: dedicated mode bit

c166.sinc: add ExtpRegMode and ExtsRegMode (1 bit each) in the contextreg. The Sleigh Set{Extp,Exts}{,Ind} macros now set:
register-mode: RegMode = 1; Reg = rwm
immediate-mode: RegMode = 0; Reg = 0
ExtCountDec clears both alongside the existing En bits.
RegOffsetAddr.readEffectiveExt and C166AddressAnalyzer.getExtValue now consult RegMode instead of probing the index for 0xF. Functionally equivalent for register indices 0..14, fixed for 15.
Why one PR
Splitting these into two PRs would leave commit #1 in main as a regression risk: it advertises register-mode support and makes existing immediate-mode behaviour slightly more code, but produces no observable improvement in real firmware (every register-mode site that actually matters uses r15). Combining them keeps the branch at every commit functionally complete.

Testing
Tested on a Keil-built C166 firmware (Infineon C167CR target):

~17.4k phantom refs at low-window addresses (0x0xxxx) had already been cleared by #31/#32/#34 for direct/indirect addressing.
This PR additionally resolves the residual register-mode sites. In the test firmware, this fixes ~10–20 sites per affected function across all functions that follow the typical mov rN,#offset; mov rM,#page; extp rM,#1; mov [rN+#imm],… pattern. Concretely: refs that previously landed at 0x00xxxx now land at (page << 14) | (offset + imm), matching what hardware actually addresses.
Decompiler output now resolves struct-field access through the paged base (e.g. g_DiagState._pad_002._46_2_ instead of _DAT_003214).
Build note for reviewers
Adding new context bits requires regenerating c166.sla. ./gradlew buildExtension does not run the SLEIGH compiler; you need:


$GHIDRA_INSTALL_DIR/support/sleigh -e data/languages/c166.slaspec
before building the extension.

Limitation (out of scope)
GetPagedOffset.java (the pcode-inject for direct 16-bit addresses) has the analogous register-mode hole, but it folds the address to a single constant at pcode-generation time and would need a structural rewrite to emit a varnode-based computation. In practice the compiler doesn't combine register-mode EXTP/EXTS with direct 16-bit addresses (register-mode pages pair with register-mode offsets), so this remains a theoretical case. Worth a follow-up PR if anyone hits it.