### PR TITLE
Build releases with Ghidra 12.1.2

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 env:
-  GHIDRA_VERSION: "12.1"
-  GHIDRA_BUILD_DATE: "20260513"
+  GHIDRA_VERSION: "12.1.2"
+  GHIDRA_BUILD_DATE: "20260605"
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -59,5 +59,9 @@ dependencies {
 	// this extension is built.	
 }
 
+buildExtension.doFirst {
+	delete 'data/languages/c166.sla'
+}
+
 // Exclude additional files from the built extension
 // Ex: buildExtension.exclude '.idea/**'


### PR DESCRIPTION
## Summary
- build CI releases against Ghidra 12.1.2 (20260605)
- remove any locally generated c166.sla before packaging so release ZIPs ship SLEIGH sources only

## Verification
- buildExtension succeeds with Ghidra 12.1.2
- generated extension ZIP contains no .sla