### PR TITLE
Fix C166SwitchOverride for current Ghidra API

### DIFF
--- a/ghidra_scripts/C166SwitchOverride.java
+++ b/ghidra_scripts/C166SwitchOverride.java
@@ -373,7 +373,7 @@ public class C166SwitchOverride extends GhidraScript {
 
         // Create the JumpTable override for the decompiler
         // This automatically creates labels: override::jmp_XXX::case_N
-        JumpTable jumpTable = new JumpTable(switchAddr, targets, true);
+        JumpTable jumpTable = new JumpTable(switchAddr, targets, true, 0);
         jumpTable.writeOverride(func);
 
         // Fix up function body to include all switch targets


### PR DESCRIPTION
## Summary
- update `JumpTable` construction for current Ghidra API
- preserve default case-label display format with `0`

## Verification
- compiled `C166SwitchOverride.java` against installed Ghidra 12.1.2 jars
- `./gradlew buildExtension`

Closes #44